### PR TITLE
Add 'weak' to delegate property definition

### DIFF
--- a/src/SNTrimController.swift
+++ b/src/SNTrimController.swift
@@ -54,7 +54,7 @@ class SNTrimController: UIViewController {
             self.verticalBuffer = device.newBufferWithLength(4 * Int(size.width), options: [.StorageModeShared])
         }
     }
-    var delegate:SNTrimControllerDelegate!
+    weak var delegate:SNTrimControllerDelegate!
     
     // Metal
     static let device = MTLCreateSystemDefaultDevice()


### PR DESCRIPTION
Added `weak` to `var delegate:SNTrimControllerDelegate!` in SNTrimController to avoid strong cyclic reference.
